### PR TITLE
fix:breadcrumb组件去除展平路由

### DIFF
--- a/src/components/common/breadcrumb/index.tsx
+++ b/src/components/common/breadcrumb/index.tsx
@@ -3,12 +3,9 @@ import { useHistory } from 'react-router-dom'
 import withBreadcrumbs from 'react-router-breadcrumbs-hoc'
 import { Breadcrumb, Button } from 'antd'
 import routes from '@/route/routes'
-import { flattenRoutes } from '@/assets/js/publicFunc'
-
-const allRoutes = flattenRoutes(routes)
 
 interface Props {
-  breadcrumbs: any[];
+  breadcrumbs: any[]
 }
 
 // 通用面包屑
@@ -39,4 +36,4 @@ const Breadcrumbs: FC<Props> = ({ breadcrumbs }) => {
   )
 }
 
-export default withBreadcrumbs(allRoutes)(Breadcrumbs)
+export default withBreadcrumbs(routes)(Breadcrumbs)


### PR DESCRIPTION
1. 最新版本的react-router-breadcrumbs-hoc会为传进来的路由routes进行扁平化处理，代码有点重复了
https://github.com/icd2k3/react-router-breadcrumbs-hoc/blob/8675c1e5076c399311e09b631bdbcf79b43990c2/src/index.tsx#L293


![企业微信截图_16478347347251](https://user-images.githubusercontent.com/38551485/159203769-a2cb276f-8f39-4bdd-9653-ecb838c15c71.png)
)